### PR TITLE
영속성 관련 의존성 추가 및 클래스들과 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,15 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // MySQL 드라이버
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // TestContainers
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yoger/productserviceorganization/proruct/config/DataConfig.java
+++ b/src/main/java/com/yoger/productserviceorganization/proruct/config/DataConfig.java
@@ -1,0 +1,9 @@
+package com.yoger.productserviceorganization.proruct.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class DataConfig {
+}

--- a/src/main/java/com/yoger/productserviceorganization/proruct/domain/ProductState.java
+++ b/src/main/java/com/yoger/productserviceorganization/proruct/domain/ProductState.java
@@ -1,0 +1,7 @@
+package com.yoger.productserviceorganization.proruct.domain;
+
+public enum ProductState {
+    DEMO,
+    FINISHED,
+    SALE_ENDED
+}

--- a/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductEntity.java
+++ b/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductEntity.java
@@ -13,53 +13,59 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.stereotype.Service;
 
 @Entity
-public record ProductEntity(
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        Long id,
+@Getter @Service
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-        @NotBlank(message = "상품 이름을 작성해주세요.")
-        @Size(min = 2, max = 50, message = "상품 이름은 2글자 이상 50글자 이하만 가능합니다.")
-        @Pattern(
-                regexp = "^[가-힣a-zA-Z0-9\\-\\_ ]+$",
-                message = "상품 이름은 한글, 영어, 숫자, '-', '_' 만 사용할 수 있습니다."
-        )
-        String name,
+    @NotBlank(message = "상품 이름을 작성해주세요.")
+    @Size(min = 2, max = 50, message = "상품 이름은 2글자 이상 50글자 이하만 가능합니다.")
+    @Pattern(
+            regexp = "^[가-힣a-zA-Z0-9\\-\\_ ]+$",
+            message = "상품 이름은 한글, 영어, 숫자, '-', '_' 만 사용할 수 있습니다."
+    )
+    private String name;
 
-        @Nullable
-        String priceByQuantity,
+    @Nullable
+    private String priceByQuantity;
 
-        @NotBlank(message = "상품에 대한 설명을 적어주세요.")
-        @Size(min = 10, max = 500, message = "상품 상세 설명은 10글자 이상 500글자 이하만 가능합니다.")
-        String description,
+    @NotBlank(message = "상품에 대한 설명을 적어주세요.")
+    @Size(min = 10, max = 500, message = "상품 상세 설명은 10글자 이상 500글자 이하만 가능합니다.")
+    private String description;
 
-        @NotNull(message = "상품에 대한 사진을 추가해주세요.")
-        @Pattern(
-                regexp = "^(https?)://[a-zA-Z0-9\\-]+\\.s3\\.[a-zA-Z0-9\\-]+\\.amazonaws\\.com/.*$",
-                message = "유효한 S3 URL 형식이어야 합니다."
-        )
-        String imageUrl,
+    @NotNull(message = "상품에 대한 사진을 추가해주세요.")
+    @Pattern(
+            regexp = "^(https?)://[a-zA-Z0-9\\-]+\\.s3\\.[a-zA-Z0-9\\-]+\\.amazonaws\\.com/.*$",
+            message = "유효한 S3 URL 형식이어야 합니다."
+    )
+    private String imageUrl;
 
-        @NotNull(message = "상품의 상태를 정해주세요.")
-        @Enumerated(EnumType.STRING)
-        ProductState state,
+    @NotNull(message = "상품의 상태를 정해주세요.")
+    @Enumerated(EnumType.STRING)
+    private ProductState state;
 
-        @CreatedDate
-        LocalDateTime createdDate,
+    @CreatedDate
+    private LocalDateTime createdDate;
 
-        @LastModifiedDate
-        LocalDateTime lastModifiedDate
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
 
-        /*
-         * @Version을 통한 낙관적 락킹을 할 수 있지만,
-         * Product의 경우에는 다수의 사용자가 동일한 상품을 수정하는 경우는
-         * 존재하지 않기 때문에 작성하지 않음
-         */
-) {
+    /*
+     * @Version을 통한 낙관적 락킹을 할 수 있지만,
+     * Product의 경우에는 다수의 사용자가 동일한 상품을 수정하는 경우는
+     * 존재하지 않기 때문에 작성하지 않음
+     */
     public static ProductEntity of(String name, String priceByQuantity, String description, String imageUrl,
                                    ProductState state) {
         return new ProductEntity(null, name, priceByQuantity, description, imageUrl, state, null, null);

--- a/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductEntity.java
+++ b/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductEntity.java
@@ -1,0 +1,67 @@
+package com.yoger.productserviceorganization.proruct.persistence;
+
+import com.yoger.productserviceorganization.proruct.domain.ProductState;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity
+public record ProductEntity(
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        Long id,
+
+        @NotBlank(message = "상품 이름을 작성해주세요.")
+        @Size(min = 2, max = 50, message = "상품 이름은 2글자 이상 50글자 이하만 가능합니다.")
+        @Pattern(
+                regexp = "^[가-힣a-zA-Z0-9\\-\\_ ]+$",
+                message = "상품 이름은 한글, 영어, 숫자, '-', '_' 만 사용할 수 있습니다."
+        )
+        String name,
+
+        @Nullable
+        String priceByQuantity,
+
+        @NotBlank(message = "상품에 대한 설명을 적어주세요.")
+        @Size(min = 10, max = 500, message = "상품 상세 설명은 10글자 이상 500글자 이하만 가능합니다.")
+        String description,
+
+        @NotNull(message = "상품에 대한 사진을 추가해주세요.")
+        @Pattern(
+                regexp = "^(https?)://[a-zA-Z0-9\\-]+\\.s3\\.[a-zA-Z0-9\\-]+\\.amazonaws\\.com/.*$",
+                message = "유효한 S3 URL 형식이어야 합니다."
+        )
+        String imageUrl,
+
+        @NotNull(message = "상품의 상태를 정해주세요.")
+        @Enumerated(EnumType.STRING)
+        ProductState state,
+
+        @CreatedDate
+        LocalDateTime createdDate,
+
+        @LastModifiedDate
+        LocalDateTime lastModifiedDate
+
+        /*
+         * @Version을 통한 낙관적 락킹을 할 수 있지만,
+         * Product의 경우에는 다수의 사용자가 동일한 상품을 수정하는 경우는
+         * 존재하지 않기 때문에 작성하지 않음
+         */
+) {
+    public static ProductEntity of(String name, String priceByQuantity, String description, String imageUrl,
+                                   ProductState state) {
+        return new ProductEntity(null, name, priceByQuantity, description, imageUrl, state, null, null);
+    }
+}

--- a/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductEntity.java
+++ b/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductEntity.java
@@ -18,10 +18,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.stereotype.Service;
 
 @Entity
-@Getter @Service
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProductEntity {

--- a/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductRepository.java
+++ b/src/main/java/com/yoger/productserviceorganization/proruct/persistence/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.yoger.productserviceorganization.proruct.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
+}

--- a/src/test/java/com/yoger/productserviceorganization/ProductServiceOrganizationApplicationTests.java
+++ b/src/test/java/com/yoger/productserviceorganization/ProductServiceOrganizationApplicationTests.java
@@ -2,8 +2,10 @@ package com.yoger.productserviceorganization;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration")
 class ProductServiceOrganizationApplicationTests {
 
     @Test

--- a/src/test/java/com/yoger/productserviceorganization/product/persistence/ProductEntityValidationTest.java
+++ b/src/test/java/com/yoger/productserviceorganization/product/persistence/ProductEntityValidationTest.java
@@ -1,0 +1,119 @@
+package com.yoger.productserviceorganization.product.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yoger.productserviceorganization.proruct.domain.ProductState;
+import com.yoger.productserviceorganization.proruct.persistence.ProductEntity;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ProductEntityValidationTest {
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 ProductEntity 생성 - 검증 통과")
+    void validProductEntityCreation() {
+        ProductEntity productEntity = ProductEntity.of(
+                "유효한상품이름",
+                "{100, 15000}",
+                "상품에 대한 설명입니다.",
+                "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                ProductState.FINISHED
+        );
+
+        Set<ConstraintViolation<ProductEntity>> violations = validator.validate(productEntity);
+        assertThat(violations).isEmpty(); // 유효한 경우, 제약 위반이 없어야 함
+    }
+
+    @Test
+    @DisplayName("상품 이름이 짧을 경우 - 검증 실패")
+    void productNameTooShort() {
+        ProductEntity productEntity = ProductEntity.of(
+                "짧",
+                "{100, 15000}",
+                "상품에 대한 설명입니다.",
+                "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                ProductState.FINISHED
+        );
+
+        Set<ConstraintViolation<ProductEntity>> violations = validator.validate(productEntity);
+        assertThat(violations).hasSize(1); // 제약 위반이 1개여야 함
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("상품 이름은 2글자 이상 50글자 이하만 가능합니다.");
+    }
+
+    @Test
+    @DisplayName("상품 이름에 허용되지 않은 특수 문자가 포함된 경우 - 검증 실패")
+    void productNameWithInvalidCharacters() {
+        ProductEntity productEntity = ProductEntity.of(
+                "잘못된#상품이름!",
+                "{100, 15000}",
+                "상품에 대한 설명입니다.",
+                "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                ProductState.FINISHED
+        );
+
+        Set<ConstraintViolation<ProductEntity>> violations = validator.validate(productEntity);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("상품 이름은 한글, 영어, 숫자, '-', '_' 만 사용할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("상품 설명이 너무 짧을 경우 - 검증 실패")
+    void productDescriptionTooShort() {
+        ProductEntity productEntity = ProductEntity.of(
+                "유효한상품이름",
+                "{100, 15000}",
+                "짧음",
+                "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                ProductState.FINISHED
+        );
+
+        Set<ConstraintViolation<ProductEntity>> violations = validator.validate(productEntity);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("상품 상세 설명은 10글자 이상 500글자 이하만 가능합니다.");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 S3 URL일 경우 - 검증 실패")
+    void productInvalidS3Url() {
+        ProductEntity productEntity = ProductEntity.of(
+                "유효한상품이름",
+                "{100, 15000}",
+                "상품에 대한 설명입니다.",
+                "https://invalid-url.com/image.jpg",
+                ProductState.FINISHED
+        );
+
+        Set<ConstraintViolation<ProductEntity>> violations = validator.validate(productEntity);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("유효한 S3 URL 형식이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("ProductState가 null일 경우 - 검증 실패")
+    void productStateNull() {
+        ProductEntity productEntity = ProductEntity.of(
+                "유효한상품이름",
+                "{100, 15000}",
+                "상품에 대한 설명입니다.",
+                "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                null
+        );
+
+        Set<ConstraintViolation<ProductEntity>> violations = validator.validate(productEntity);
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("상품의 상태를 정해주세요.");
+    }
+}

--- a/src/test/java/com/yoger/productserviceorganization/product/persistence/ProductRepositoryJpaTests.java
+++ b/src/test/java/com/yoger/productserviceorganization/product/persistence/ProductRepositoryJpaTests.java
@@ -1,0 +1,107 @@
+package com.yoger.productserviceorganization.product.persistence;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.yoger.productserviceorganization.proruct.config.DataConfig;
+import com.yoger.productserviceorganization.proruct.domain.ProductState;
+import com.yoger.productserviceorganization.proruct.persistence.ProductEntity;
+import com.yoger.productserviceorganization.proruct.persistence.ProductRepository;
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(DataConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("integration")
+public class ProductRepositoryJpaTests {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    @DisplayName("상품들이 정상적으로 저장되었는 지 테스트")
+    void findAllProducts() {
+        ProductEntity productEntity1 = ProductEntity.of(
+                "유효한상품이름1",
+                "{100, 15000}",
+                "상품에 대한 설명입니다.",
+                "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                ProductState.FINISHED
+        );
+        ProductEntity productEntity2 = ProductEntity.of(
+                "유효한상품이름2",
+                "{100, 15000}",
+                "상품에 대한 설명입니다.",
+                "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                ProductState.FINISHED
+        );
+        productRepository.save(productEntity1);
+        productRepository.save(productEntity2);
+
+        List<ProductEntity> actualProducts = productRepository.findAll();
+
+        assertThat(actualProducts.parallelStream()
+                .filter(productEntity -> productEntity.getName().equals(productEntity1.getName()) || productEntity.getName()
+                        .equals(productEntity2.getName()))
+                .collect(Collectors.toList())).hasSize(2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidProductParameters")
+    @DisplayName("유효성 검증 실패 테스트 - 다양한 경우")
+    void productValidationFailTest(String name, String description, String imageUrl, ProductState state, String expectedMessage) {
+        ProductEntity productEntity = ProductEntity.of(
+                name,
+                "{100, 15000}",
+                description,
+                imageUrl,
+                state
+        );
+
+        assertThatThrownBy(() -> productRepository.save(productEntity))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining(expectedMessage);
+    }
+
+    // 유효성 실패 케이스들을 제공하는 메서드
+    private static Stream<Arguments> invalidProductParameters() {
+        return Stream.of(
+                // name 유효성 검증 실패 케이스
+                Arguments.of("짧", "상품에 대한 설명입니다.", "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                        ProductState.FINISHED, "상품 이름은 2글자 이상 50글자 이하만 가능합니다."),
+                Arguments.of("이름이 너무너무 길어요".repeat(10), "상품에 대한 설명입니다.",
+                        "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg", ProductState.FINISHED,
+                        "상품 이름은 2글자 이상 50글자 이하만 가능합니다."),
+                Arguments.of("이름에 허용하지 않은 특수부호 #", "상품에 대한 설명입니다.",
+                        "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg", ProductState.FINISHED,
+                        "상품 이름은 한글, 영어, 숫자, '-', '_' 만 사용할 수 있습니다."),
+
+                // description 유효성 검증 실패 케이스
+                Arguments.of("정상 이름", "짧", "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg",
+                        ProductState.FINISHED, "상품 상세 설명은 10글자 이상 500글자 이하만 가능합니다."),
+                Arguments.of("정상 이름", "상품 설명이 너무 길어요".repeat(100),
+                        "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg", ProductState.FINISHED,
+                        "상품 상세 설명은 10글자 이상 500글자 이하만 가능합니다."),
+
+                // imageUrl 유효성 검증 실패 케이스
+                Arguments.of("정상 이름", "상품에 대한 설명입니다.", "https://wrong-url.com/myimage.jpg", ProductState.FINISHED,
+                        "유효한 S3 URL 형식이어야 합니다."),
+
+                // state 유효성 검증 실패 케이스
+                Arguments.of("정상 이름", "상품에 대한 설명입니다.", "https://my-bucket.s3.us-west-1.amazonaws.com/myimage.jpg", null,
+                        "상품의 상태를 정해주세요.")
+        );
+    }
+}

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -1,6 +1,3 @@
 spring:
   datasource:
     url: jdbc:tc:mysql:8.0.39:///
-  jpa:
-    hibernate:
-      ddl-auto: create-drop

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:tc:mysql:8.0.39:///
+  jpa:
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
현재 영속성 관련하여, JPA를 사용할 것이기에 implementation 'org.springframework.boot:spring-boot-starter-data-jpa' 의존성을 추가하였고, DB의 경우는 MySQL을 사용할 것이기 때문에 runtimeOnly 'com.mysql:mysql-connector-j' 종속성을 추가하였습니다.

클래스 구조는 product/persistence에 ProductEntity라는 영속성 엔티티 클래스와 JPA를 사용하는 ProductRepository 인터페이스를 만들었습니다.
그리고 ProductEntity의 경우에는 생성자 대신하여 사용될 명확한 의미의 of 메서드를 추가했고,
implementation 'org.springframework.boot:spring-boot-starter-validation' 의존성을 추가하고 이를 사용하여 ProductEntity 필드에서 어노테이션 기반 검증을 진행하였습니다. 이로 인해, DB에 저장되기 전 Validation이 진행되어 조건에 불만족할 경우 save가 되지 않도록 만들었습니다.

또한, 이러한 환경과 동일하게 슬라이싱 테스트를 하기 위한 MySQL TestContainer 의존성을 추가하고 슬라이싱 테스트 또한 마쳤습니다.
이 테스트에선 위에서 말한 필드 관련 제한 검증 진행과 MySQL과 연결과 호환성에 문제가 없는 지 확인하였습니다.
