### PR TITLE
fix:  배치 리스너 per-record 트레이싱 적용 및 outbox 컨텍스트 저장 (#44)

### DIFF
--- a/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionCompletedEvent.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionCompletedEvent.java
@@ -10,7 +10,7 @@ public record DeductionCompletedEvent(
         String eventType,
         DeductionCompletedEventData data,
         LocalDateTime occurrenceDateTime,
-        String tracingProps
+        String tracingSpanContext
 ) {
     public record DeductionCompletedEventData(
             Long orderId,
@@ -21,7 +21,7 @@ public record DeductionCompletedEvent(
         }
     }
 
-    public static DeductionCompletedEvent from(Long productId, DeductStockCommandFromOrder command, String tracingProps) {
+    public static DeductionCompletedEvent from(Long productId, DeductStockCommandFromOrder command, String tracingSpanContext) {
         return new DeductionCompletedEvent(
                 UUID.randomUUID().toString(),
                 productId,
@@ -31,7 +31,7 @@ public record DeductionCompletedEvent(
                         command.getDeductStockCommand().getQuantity()
                 ),
                 LocalDateTime.now(),
-                tracingProps
+                tracingSpanContext
         );
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionCompletedEvent.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionCompletedEvent.java
@@ -9,8 +9,8 @@ public record DeductionCompletedEvent(
         Long productId,
         String eventType,
         DeductionCompletedEventData data,
-        LocalDateTime occurrenceDateTime
-
+        LocalDateTime occurrenceDateTime,
+        String tracingProps
 ) {
     public record DeductionCompletedEventData(
             Long orderId,
@@ -21,7 +21,7 @@ public record DeductionCompletedEvent(
         }
     }
 
-    public static DeductionCompletedEvent from(Long productId, DeductStockCommandFromOrder command) {
+    public static DeductionCompletedEvent from(Long productId, DeductStockCommandFromOrder command, String tracingProps) {
         return new DeductionCompletedEvent(
                 UUID.randomUUID().toString(),
                 productId,
@@ -30,7 +30,8 @@ public record DeductionCompletedEvent(
                         command.getOrderId(),
                         command.getDeductStockCommand().getQuantity()
                 ),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                tracingProps
         );
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionFailedEvent.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionFailedEvent.java
@@ -10,7 +10,7 @@ public record DeductionFailedEvent(
         String eventType,
         DeductionFailedEventData data,
         LocalDateTime occurrenceDateTime,
-        String tracingProps
+        String tracingSpanContext
 ) {
     public record DeductionFailedEventData(
             Long orderId,

--- a/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionFailedEvent.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/adapters/messaging/kafka/producer/event/DeductionFailedEvent.java
@@ -9,8 +9,8 @@ public record DeductionFailedEvent(
         Long productId,
         String eventType,
         DeductionFailedEventData data,
-        LocalDateTime occurrenceDateTime
-
+        LocalDateTime occurrenceDateTime,
+        String tracingProps
 ) {
     public record DeductionFailedEventData(
             Long orderId,
@@ -21,7 +21,7 @@ public record DeductionFailedEvent(
         }
     }
 
-    public static DeductionFailedEvent from(Long productId, DeductStockCommandFromOrder command) {
+    public static DeductionFailedEvent from(Long productId, DeductStockCommandFromOrder command, String tracingProps) {
         return new DeductionFailedEvent(
                 UUID.randomUUID().toString(),
                 productId,
@@ -30,7 +30,8 @@ public record DeductionFailedEvent(
                         command.getOrderId(),
                         command.getDeductStockCommand().getQuantity()
                 ),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                tracingProps
         );
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/adapters/persistence/jpa/OutboxEventJpaEntity.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/adapters/persistence/jpa/OutboxEventJpaEntity.java
@@ -1,6 +1,5 @@
 package com.yoger.productserviceorganization.product.adapters.persistence.jpa;
 
-import com.yoger.productserviceorganization.global.config.TraceUtil;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -17,48 +16,46 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 class OutboxEventJpaEntity {
+
     @Id
     private String id;
 
-    @Column(name="tracingspancontext")
+    @Column(name = "tracingspancontext", columnDefinition = "TEXT", nullable = false)
     private String tracingSpanContext;
 
-    private String aggregate_type;
+    @Column(name = "aggregate_type")
+    private String aggregateType;
 
-    private String aggregateid;
+    @Column(name = "aggregateid")
+    private String aggregateId;
 
-    private String event_type;
+    @Column(name = "event_type")
+    private String eventType;
 
     @Lob
-    private String payload; // DeductionCompletedEvent JSON
+    @Column(name = "payload", columnDefinition = "LONGTEXT", nullable = false)
+    private String payload;
 
-    private LocalDateTime created_at;
-
-    private OutboxEventJpaEntity(
-            String id,
-            String aggregateType,
-            String aggregateId,
-            String eventType,
-            String payload,
-            LocalDateTime createdAt
-    ) {
-        this.id = id;
-        this.tracingSpanContext = TraceUtil.serializedTracingProperties();
-        this.aggregate_type = aggregateType;
-        this.aggregateid = aggregateId;
-        this.event_type = eventType;
-        this.payload = payload;
-        this.created_at = createdAt;
-    }
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     public static OutboxEventJpaEntity of(
-            String id,
-            String aggregateType,
-            String aggregateId,
-            String eventType,
-            String payload,
-            LocalDateTime createdAt
+            final String id,
+            final String aggregateType,
+            final String aggregateId,
+            final String eventType,
+            final String payload,
+            final LocalDateTime createdAt,
+            final String tracingSpanContext
     ) {
-        return new OutboxEventJpaEntity(id, aggregateType, aggregateId, eventType, payload, createdAt);
+        OutboxEventJpaEntity entity = new OutboxEventJpaEntity();
+        entity.id = id;
+        entity.aggregateType = aggregateType;
+        entity.aggregateId = aggregateId;
+        entity.eventType = eventType;
+        entity.payload = payload;
+        entity.createdAt = createdAt;
+        entity.tracingSpanContext = tracingSpanContext;
+        return entity;
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/adapters/persistence/jpa/OutboxEventMapper.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/adapters/persistence/jpa/OutboxEventMapper.java
@@ -1,18 +1,22 @@
 package com.yoger.productserviceorganization.product.adapters.persistence.jpa;
 
 import com.yoger.productserviceorganization.product.domain.event.OutboxEvent;
+import java.util.Objects;
 
 final class OutboxEventMapper {
-    private OutboxEventMapper() {}
 
-    static OutboxEventJpaEntity toEntity(OutboxEvent domain) {
+    private OutboxEventMapper() { }
+
+    static OutboxEventJpaEntity toEntity(final OutboxEvent domain) {
+        Objects.requireNonNull(domain, "domain must not be null");
         return OutboxEventJpaEntity.of(
                 domain.id(),
                 domain.aggregateType(),
                 domain.aggregateId(),
                 domain.eventType(),
                 domain.payload(),
-                domain.createdAt()
+                domain.createdAt(),
+                domain.tracingSpanContext()
         );
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/application/port/in/DeductStockFromOrdersUseCase.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/application/port/in/DeductStockFromOrdersUseCase.java
@@ -1,7 +1,9 @@
 package com.yoger.productserviceorganization.product.application.port.in;
 
 import com.yoger.productserviceorganization.product.application.port.in.command.DeductStockBatchCommandFromOrder;
+import java.util.List;
 
 public interface DeductStockFromOrdersUseCase {
-    void deductStockFromOrders(DeductStockBatchCommandFromOrder deductStockBatchCommandFromOrder);
+    void deductStockFromOrders(DeductStockBatchCommandFromOrder batchCommand,
+                               List<String> tracingSpanContexts);
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/application/port/service/DeductStockFromOrdersService.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/application/port/service/DeductStockFromOrdersService.java
@@ -72,14 +72,14 @@ public class DeductStockFromOrdersService implements DeductStockFromOrdersUseCas
     private OutboxEvent processSingleCommand(
             final Product product,
             final DeductStockCommandFromOrder command,
-            final String tracingProps
+            final String tracingSpanContext
     ) {
         try {
             final int quantity = command.getDeductStockCommand().getQuantity();
             product.deductStockQuantity(quantity);
-            return outboxEventFactory.createDeductionCompletedEvent(command, tracingProps);
+            return outboxEventFactory.createDeductionCompletedEvent(command, tracingSpanContext);
         } catch (final InsufficientStockException ex) {
-            return outboxEventFactory.createDeductionFailedEvent(command, tracingProps);
+            return outboxEventFactory.createDeductionFailedEvent(command, tracingSpanContext);
         }
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/application/port/service/DeductStockFromOrdersService.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/application/port/service/DeductStockFromOrdersService.java
@@ -1,54 +1,85 @@
 package com.yoger.productserviceorganization.product.application.port.service;
 
 import com.yoger.productserviceorganization.product.application.port.in.DeductStockFromOrdersUseCase;
-import com.yoger.productserviceorganization.product.application.port.in.command.DeductStockCommandFromOrder;
 import com.yoger.productserviceorganization.product.application.port.in.command.DeductStockBatchCommandFromOrder;
+import com.yoger.productserviceorganization.product.application.port.in.command.DeductStockCommandFromOrder;
 import com.yoger.productserviceorganization.product.application.port.out.LoadProductPort;
 import com.yoger.productserviceorganization.product.application.port.out.PersistProductPort;
 import com.yoger.productserviceorganization.product.application.port.out.SaveOutboxEventPort;
 import com.yoger.productserviceorganization.product.domain.event.OutboxEvent;
 import com.yoger.productserviceorganization.product.domain.exception.InsufficientStockException;
 import com.yoger.productserviceorganization.product.domain.model.Product;
+import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class DeductStockFromOrdersService implements DeductStockFromOrdersUseCase {
+
     private final LoadProductPort loadProductPort;
     private final SaveOutboxEventPort saveOutboxEventPort;
     private final PersistProductPort persistProductPort;
     private final OutboxEventFactory outboxEventFactory;
 
     @Override
-    public void deductStockFromOrders(DeductStockBatchCommandFromOrder batchCommand) {
-        Product product = loadProductPort.loadProductWithLock(batchCommand.getProductId());
-        List<OutboxEvent> outboxEvents = processDeductStockCommands(product, batchCommand);
+    public void deductStockFromOrders(
+            final DeductStockBatchCommandFromOrder batch,
+            final List<String> tracingSpanContexts
+    ) {
+        final Product product = loadProductPort.loadProductWithLock(batch.getProductId());
+
+        final List<DeductStockCommandFromOrder> commands = batch.getDeductStockCommands();
+        validateCommandAndTracingSize(commands, tracingSpanContexts);
+
+        final List<OutboxEvent> outboxEvents =
+                buildOutboxEvents(product, commands, tracingSpanContexts);
 
         saveOutboxEventPort.saveAll(outboxEvents);
-
         persistProductPort.persist(product);
     }
 
-    private List<OutboxEvent> processDeductStockCommands(
-            Product product,
-            DeductStockBatchCommandFromOrder batchCommand
+    private static void validateCommandAndTracingSize(
+            final List<DeductStockCommandFromOrder> commands,
+            final List<String> tracingSpanContexts
     ) {
-        List<OutboxEvent> outboxEvents = new ArrayList<>();
+        if (commands.size() != tracingSpanContexts.size()) {
+            throw new IllegalArgumentException(
+                    "commands.size != tracingSpanContexts.size: " +
+                            commands.size() + " vs " + tracingSpanContexts.size()
+            );
+        }
+    }
 
-        for (DeductStockCommandFromOrder command : batchCommand.getDeductStockCommands()) {
-            int orderQuantity = command.getDeductStockCommand().getQuantity();
-            try {
-                product.deductStockQuantity(orderQuantity);
-                outboxEvents.add(outboxEventFactory.createDeductionCompletedEvent(command));
-            } catch (InsufficientStockException e) {
-                outboxEvents.add(outboxEventFactory.createDeductionFailedEvent(command));
-            }
+    private List<OutboxEvent> buildOutboxEvents(
+            final Product product,
+            final List<DeductStockCommandFromOrder> commands,
+            final List<String> tracingSpanContexts
+    ) {
+        final List<OutboxEvent> outboxEvents = new ArrayList<>(commands.size());
+        for (int i = 0; i < commands.size(); i++) {
+            final DeductStockCommandFromOrder command = commands.get(i);
+            final String tracingProps = tracingSpanContexts.get(i);
+            final OutboxEvent event = processSingleCommand(product, command, tracingProps);
+            outboxEvents.add(event);
         }
         return outboxEvents;
+    }
+
+    private OutboxEvent processSingleCommand(
+            final Product product,
+            final DeductStockCommandFromOrder command,
+            final String tracingProps
+    ) {
+        try {
+            final int quantity = command.getDeductStockCommand().getQuantity();
+            product.deductStockQuantity(quantity);
+            return outboxEventFactory.createDeductionCompletedEvent(command, tracingProps);
+        } catch (final InsufficientStockException ex) {
+            return outboxEventFactory.createDeductionFailedEvent(command, tracingProps);
+        }
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/application/port/service/OutboxEventFactory.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/application/port/service/OutboxEventFactory.java
@@ -15,36 +15,81 @@ public class OutboxEventFactory {
 
     private final ObjectMapper objectMapper;
 
-    public OutboxEvent createDeductionCompletedEvent(DeductStockCommandFromOrder command) {
-        return createEvent(
-                DeductionCompletedEvent.from(command.getDeductStockCommand().getProductId(), command)
-        );
+    public OutboxEvent createDeductionCompletedEvent(
+            final DeductStockCommandFromOrder command,
+            final String tracingProps
+    ) {
+        final DeductionCompletedEvent event =
+                DeductionCompletedEvent.from(
+                        command.getDeductStockCommand().getProductId(),
+                        command,
+                        tracingProps
+                );
+        return createEvent(event);
     }
 
-    public OutboxEvent createDeductionFailedEvent(DeductStockCommandFromOrder command) {
-        return createEvent(
-                DeductionFailedEvent.from(command.getDeductStockCommand().getProductId(), command)
-        );
+    public OutboxEvent createDeductionFailedEvent(
+            final DeductStockCommandFromOrder command,
+            final String tracingProps
+    ) {
+        final DeductionFailedEvent event =
+                DeductionFailedEvent.from(
+                        command.getDeductStockCommand().getProductId(),
+                        command,
+                        tracingProps
+                );
+        return createEvent(event);
     }
 
-    private OutboxEvent createEvent(Object domainEvent) {
+    private OutboxEvent createEvent(final Object domainEvent) {
+        final String payload;
         try {
-            String payload = objectMapper.writeValueAsString(domainEvent);
-
-            if (domainEvent instanceof DeductionCompletedEvent event) {
-                return buildOutbox(event.eventId(), event.productId(), event.eventType(), payload, event.occurrenceDateTime());
-            }
-            if (domainEvent instanceof DeductionFailedEvent event) {
-                return buildOutbox(event.eventId(), event.productId(), event.eventType(), payload, event.occurrenceDateTime());
-            }
-
-            throw new IllegalArgumentException("Unsupported event type: " + domainEvent.getClass().getSimpleName());
+            payload = objectMapper.writeValueAsString(domainEvent);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to serialize event: " + domainEvent.getClass().getSimpleName(), e);
+            throw new IllegalStateException(
+                    "Failed to serialize domain event: " + domainEvent.getClass().getSimpleName(), e
+            );
         }
+
+        if (domainEvent instanceof DeductionCompletedEvent completed) {
+            return toOutbox(completed, payload);
+        }
+        if (domainEvent instanceof DeductionFailedEvent failed) {
+            return toOutbox(failed, payload);
+        }
+
+        throw new IllegalArgumentException(
+                "Unsupported event type: " + domainEvent.getClass().getName()
+        );
     }
 
-    private OutboxEvent buildOutbox(String eventId, Long productId, String eventType, String payload, java.time.LocalDateTime time) {
-        return OutboxEvent.of(eventId, productId.toString(), eventType, payload, time);
+    // --- Mappers -------------------------------------------------------------
+
+    private static OutboxEvent toOutbox(
+            final DeductionCompletedEvent event,
+            final String payload
+    ) {
+        return OutboxEvent.of(
+                event.eventId(),
+                String.valueOf(event.productId()),
+                event.eventType(),
+                payload,
+                event.occurrenceDateTime(),
+                event.tracingProps()
+        );
+    }
+
+    private static OutboxEvent toOutbox(
+            final DeductionFailedEvent event,
+            final String payload
+    ) {
+        return OutboxEvent.of(
+                event.eventId(),
+                String.valueOf(event.productId()),
+                event.eventType(),
+                payload,
+                event.occurrenceDateTime(),
+                event.tracingProps()
+        );
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/application/port/service/OutboxEventFactory.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/application/port/service/OutboxEventFactory.java
@@ -17,26 +17,26 @@ public class OutboxEventFactory {
 
     public OutboxEvent createDeductionCompletedEvent(
             final DeductStockCommandFromOrder command,
-            final String tracingProps
+            final String tracingSpanContext
     ) {
         final DeductionCompletedEvent event =
                 DeductionCompletedEvent.from(
                         command.getDeductStockCommand().getProductId(),
                         command,
-                        tracingProps
+                        tracingSpanContext
                 );
         return createEvent(event);
     }
 
     public OutboxEvent createDeductionFailedEvent(
             final DeductStockCommandFromOrder command,
-            final String tracingProps
+            final String tracingSpanContext
     ) {
         final DeductionFailedEvent event =
                 DeductionFailedEvent.from(
                         command.getDeductStockCommand().getProductId(),
                         command,
-                        tracingProps
+                        tracingSpanContext
                 );
         return createEvent(event);
     }
@@ -75,7 +75,7 @@ public class OutboxEventFactory {
                 event.eventType(),
                 payload,
                 event.occurrenceDateTime(),
-                event.tracingProps()
+                event.tracingSpanContext()
         );
     }
 
@@ -89,7 +89,7 @@ public class OutboxEventFactory {
                 event.eventType(),
                 payload,
                 event.occurrenceDateTime(),
-                event.tracingProps()
+                event.tracingSpanContext()
         );
     }
 }

--- a/src/main/java/com/yoger/productserviceorganization/product/domain/event/OutboxEvent.java
+++ b/src/main/java/com/yoger/productserviceorganization/product/domain/event/OutboxEvent.java
@@ -8,15 +8,17 @@ public record OutboxEvent(
         String aggregateId,
         String eventType,
         String payload,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String tracingSpanContext
 ) {
     public static OutboxEvent of(
             String id,
             String aggregateId,
             String eventType,
             String payload,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            String tracingSpanContext
     ) {
-        return new OutboxEvent(id, "product", aggregateId, eventType, payload, createdAt);
+        return new OutboxEvent(id, "product", aggregateId, eventType, payload, createdAt, tracingSpanContext);
     }
 }


### PR DESCRIPTION
# 배경

배치 리스너에서 이벤트를 묶어서 처리할 때, Trace ID가 이벤트별로 분리되지 않고 배치의 특정 컨텍스트(주로 첫 레코드)로 덮어씌워지는 문제가 있었음.

이로 인해 outbox 및 다운스트림에서 이벤트별 분산 추적이 불가능했고, 디버깅 난이도가 높아졌음.


# 문제 원인

배치 범위에서 한 번만 makeCurrent()를 호출하거나,

outbox 저장 시점에 현재 컨텍스트를 재직렬화하여 저장(=여러 이벤트가 동일 컨텍스트로 저장)했기 때문.


# 해결 방안(핵심)

레코드별 스코핑: 각 ConsumerRecord 처리 직전에 extractFromKafkaHeaders(...).makeCurrent()를 열고, 그 블록 안에서만 직렬화 수행.

컨텍스트 전달: 레코드별로 직렬화한 tracing properties(traceparent 포함)를 커맨드와 함께 Service 계층으로 전달.

Outbox 저장: Service/Factory에서 도메인에서 온 tracingProps를 그대로 outbox.tracingspancontext에 저장(재직렬화 금지).

Debezium Outbox SMT 추가
    "transforms.activateTracing.type": "io.debezium.transforms.tracing.ActivateTracingSpan",
    "transforms.activateTracing.tracing.span.context.field": "tracingspancontext",
    "transforms.activateTracing.tracing.with.context.field.only": "true",
    "transforms.activateTracing.tracing.operation.name": "debezium-outbox-read",

# 주요 변경사항

### Consumer

@KafkaListener 파라미터를 List<ConsumerRecord<String, OrderCreatedEvent>>로 사용.

CommandWithTracing(eventId, command, tracingSpanContext) 래퍼로 중복키 + 트레이싱 묶어 전달.

배치 내/전역 중복 제거 후, 레코드별 스코프에서 직렬화(serializedTracingProperties()).

productId 기준 그룹핑 → DeductStockFromOrdersUseCase에 커맨드 리스트 + 컨텍스트 리스트 전달.

### Service

deductStockFromOrders(DeductStockBatchCommandFromOrder, List<String>) 오버로드 추가.

명시적 타입 사용(코드 전반 var 미사용), 메서드 분리(검증/단일 처리/아웃박스 생성).

### OutboxEventFactory

직렬화 실패 시 IllegalStateException.

이벤트 타입별 toOutbox(...)로 공통화, 도메인 이벤트의 tracingProps 그대로 저장.

### JPA (Outbox)

OutboxEventMapper에서 도메인 값 그대로 매핑.

OutboxEventJpaEntity는 컬럼명 정리 및 null 가드. (스키마는 마이그레이션으로 보완)

### TraceUtil

불필요 메서드 제거(최소 필요만 유지).

### Debezium 설정

Outbox SMT에 트레이싱 필드 매핑 옵션 추가.

# 결과
- resolve #44 